### PR TITLE
Add `escape_it` to enable escaping HTML for text nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+
+
+Version 1.0.8 - April 1, 2024
+-----------------------------
+
+* Add the `escape` option to convert `&`, `<` and `>` in inner string arguments to HTML-safe sequences.
+
+Version 1.07 - Jan 24, 2024
+---------------------------
+
+* add `html_to_code` function

--- a/README.rst
+++ b/README.rst
@@ -104,10 +104,34 @@ You can create your own tag using the ``tag`` function:
 <my_tag>text</my_tag>
 
 
+Options:
+========
+
+By default, the inner string of a tag is not escaped:
+characters ``&``, ``<`` and ``>`` in it are not converted to HTML-safe sequences.
+
+>>> print(render(p("<bold>text</bold>")))
+<p><bold>text</bold></p>
+
+Of course, you can escape strings before calling fast_html:
+
+>>> from html import escape
+>>> print(render(p(escape("<bold>text</bold>"))))
+<p>&lt;bold&gt;text&lt;/bold&gt;</p>
+
+If your policy is to escape every inner string,
+you can activate escaping by setting the variable ``escape`` to ``False``
+(or by calling ``escape_it(False)``).
+
+>>> escape_it(True)
+>>> print(render(p("<bold>text</bold>")))
+<p>&lt;bold&gt;text&lt;/bold&gt;</p>
+
 When debugging your code, you can set global variable ``indent`` to ``True``
 (or call ``indent_it(True)``) to obtain HTML with tag indentation, e.g.,
 
->>> indent_it(True); print(render(div(class_="s12", i=["text\n", span("item 1"), span("item 2")])))
+>>> indent_it(True)
+>>> print(render(div(class_="s12", i=["text\n", span("item 1"), span("item 2")])))
 <div class="s12">
   text
   <span>

--- a/fast_html/__init__.py
+++ b/fast_html/__init__.py
@@ -13,7 +13,7 @@ _tab = '  '
 _cr = '\n'
 
 indent: bool = False
-should_escape: bool = False
+escape: bool = False
 
 
 def indent_it(value: bool):
@@ -22,8 +22,8 @@ def indent_it(value: bool):
 
 
 def escape_it(value: bool):
-    global should_escape
-    should_escape = value
+    global escape
+    escape = value
 
 
 def render(gen: Tag) -> str:
@@ -85,7 +85,7 @@ def tag(tag_name: str, inner: Optional[Inner] = None, **kwargs) -> Tag:
     yield from solo_tag(tag_name, **kwargs)
 
     if inner is not None:
-        if should_escape and isinstance(inner, str):
+        if escape and isinstance(inner, str):
             inner = escape_html(inner)
         yield from _inner(inner, with_cr = True)
 

--- a/fast_html/__init__.py
+++ b/fast_html/__init__.py
@@ -1,6 +1,7 @@
 __version__ = '1.0.7'
 
 import re
+from html import escape as escape_html
 from typing import Iterator, Union, Optional, Iterable, Any
 
 from .utils import html_to_code
@@ -12,11 +13,17 @@ _tab = '  '
 _cr = '\n'
 
 indent: bool = False
+should_escape: bool = False
 
 
 def indent_it(value: bool):
     global indent
     indent = value
+
+
+def escape_it(value: bool):
+    global should_escape
+    should_escape = value
 
 
 def render(gen: Tag) -> str:
@@ -78,6 +85,8 @@ def tag(tag_name: str, inner: Optional[Inner] = None, **kwargs) -> Tag:
     yield from solo_tag(tag_name, **kwargs)
 
     if inner is not None:
+        if should_escape and isinstance(inner, str):
+            inner = escape_html(inner)
         yield from _inner(inner, with_cr = True)
 
     yield f"</{tag_name}>{_cr if indent else ''}"

--- a/test.py
+++ b/test.py
@@ -25,6 +25,46 @@ class HtmlToStringTesting(unittest.TestCase):
         )
 
 
+class EscapedHtmlTesting(unittest.TestCase):
+    def setUp(self):
+        escape_it(True)
+
+
+    def tearDown(self):
+        escape_it(False)
+
+
+    def test_bad_script_tag(self):
+        actual = render(div([div("<script>alert(1)</script>"), div()]))
+        expected = "<div><div>&lt;script&gt;alert(1)&lt;/script&gt;</div><div></div></div>"
+
+        self.assertEqual(
+            expected,
+            actual
+        )
+
+
+    def test_deeper_nesting(self):
+        actual = render(
+            table([
+                thead(
+                    tr([
+                        td("Student ID"),
+                        td("Name"),
+                        td("Birthday"),
+                    ])
+                ),
+                tbody()
+            ])
+        )
+        expected = "<table><thead><tr><td>Student ID</td><td>Name</td><td>Birthday</td></tr></thead><tbody></tbody></table>"
+
+        self.assertEqual(
+            expected,
+            actual
+        )
+
+
 if __name__ == '__main__':
     doctest.testfile('README.rst')
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -13,7 +13,7 @@ class PerformanceTesting(unittest.TestCase):
             ''.join(div('Content'))
         end_time = timeobj()
         execution_time = end_time - start_time
-        max_execution_time = 0.20
+        max_execution_time = 0.3
         self.assertLessEqual(execution_time, max_execution_time)
 
 
@@ -28,10 +28,12 @@ class HtmlToStringTesting(unittest.TestCase):
 class EscapedHtmlTesting(unittest.TestCase):
     def setUp(self):
         escape_it(True)
+        indent_it(False)
 
 
     def tearDown(self):
         escape_it(False)
+        indent_it(True)
 
 
     def test_bad_script_tag(self):
@@ -51,13 +53,13 @@ class EscapedHtmlTesting(unittest.TestCase):
                     tr([
                         td("Student ID"),
                         td("Name"),
-                        td("Birthday"),
+                        td("<bold>Birthday</bold>"),
                     ])
                 ),
                 tbody()
             ])
         )
-        expected = "<table><thead><tr><td>Student ID</td><td>Name</td><td>Birthday</td></tr></thead><tbody></tbody></table>"
+        expected = "<table><thead><tr><td>Student ID</td><td>Name</td><td>&lt;bold&gt;Birthday&lt;/bold&gt;</td></tr></thead><tbody></tbody></table>"
 
         self.assertEqual(
             expected,


### PR DESCRIPTION
Apologies for the redundant PR