### PR TITLE
Fix escape_it not working for lists or nested lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Of course, you can escape strings before calling fast_html:
     <p>&lt;bold&gt;text&lt;/bold&gt;</p>
 
 If your policy is to escape every inner string,
-you can activate escaping by setting the variable `escape` to `False`
-(or by calling `escape_it(False)`).
+you can activate escaping by setting the variable `escape` to `True`
+(or by calling `escape_it(True)`).
 
     >>> escape_it(True)
     >>> print(render(p("<bold>text</bold>")))

--- a/fast_html/__init__.py
+++ b/fast_html/__init__.py
@@ -66,6 +66,19 @@ def _inner(inner: Inner, with_cr = False):
             yield from _inner(i)
 
 
+def escape_inner(inner: Inner) -> Inner:
+    if isinstance(inner, str):
+        return escape_html(inner)
+
+    elif isinstance(inner, list):
+        for i, item in enumerate(inner):
+            inner[i] = escape_inner(item)
+        return inner
+
+    else:
+        return inner
+
+
 def tag(tag_name: str, inner: Optional[Inner] = None, **kwargs) -> Tag:
     """returns a generator of strings, to be rendered as a HTML tag of type `name`
 
@@ -85,8 +98,8 @@ def tag(tag_name: str, inner: Optional[Inner] = None, **kwargs) -> Tag:
     yield from solo_tag(tag_name, **kwargs)
 
     if inner is not None:
-        if escape and isinstance(inner, str):
-            inner = escape_html(inner)
+        if escape:
+            inner = escape_inner(inner)
         yield from _inner(inner, with_cr = True)
 
     yield f"</{tag_name}>{_cr if indent else ''}"

--- a/test.py
+++ b/test.py
@@ -46,6 +46,26 @@ class EscapedHtmlTesting(unittest.TestCase):
         )
 
 
+    def test_bad_script_tag_with_sibling(self):
+        actual = render(div([div(["<script>alert(1)</script>", div()]), div()]))
+        expected = "<div><div>&lt;script&gt;alert(1)&lt;/script&gt;<div></div></div><div></div></div>"
+
+        self.assertEqual(
+            expected,
+            actual
+        )
+
+
+    def test_bad_script_tag_with_nested_lists(self):
+        actual = render(div([div([["<script>alert(1)</script>"], div()]), div()]))
+        expected = "<div><div>&lt;script&gt;alert(1)&lt;/script&gt;<div></div></div><div></div></div>"
+
+        self.assertEqual(
+            expected,
+            actual
+        )
+
+
     def test_deeper_nesting(self):
         actual = render(
             table([


### PR DESCRIPTION
This fixes an edge case with the original PR.

Also fixes what I think was a typo in the README.